### PR TITLE
Unify docs.html layout: left sidebar, mobile TOC, shared post sections

### DIFF
--- a/_data/sidenav.json
+++ b/_data/sidenav.json
@@ -1,0 +1,38 @@
+[
+  { "title": "Get started", "items": [
+    { "title": "About", "url": "/about/", "icon": "fa-solid fa-circle-info" },
+    { "title": "Single sign-on", "url": "/single-sign-on/", "icon": "fa-solid fa-arrow-right-to-bracket" },
+    { "title": "Accounts", "url": "/accounts/", "icon": "fa-solid fa-user-group" },
+    { "title": "Help", "url": "/help/", "icon": "fa-solid fa-circle-question" }
+  ]},
+  { "title": "Scanning & data", "items": [
+    { "title": "Scans", "url": "/scans/", "icon": "fa-solid fa-bars-progress" },
+    { "title": "Filters", "url": "/filters/", "icon": "fa-solid fa-filter" },
+    { "title": "Data", "url": "/data/", "icon": "fa-solid fa-table" },
+    { "title": "Status", "url": "/status/", "icon": "fa-solid fa-check-circle" }
+  ]},
+  { "title": "Scoring", "items": [
+    { "title": "Grades", "url": "/grades/", "icon": "fa-solid fa-graduation-cap" },
+    { "title": "Scores", "url": "/scores/", "icon": "fa-solid fa-percent" },
+    { "title": "Overall", "url": "/overall/", "icon": "fa-solid fa-circle-notch" },
+    { "title": "Impact", "url": "/impact/", "icon": "fa-solid fa-bolt" },
+    { "title": "Rankings", "url": "/rankings/", "icon": "fa-solid fa-ranking-star" },
+    { "title": "Scorecard", "url": "/scorecard/", "icon": "fa-solid fa-star" }
+  ]},
+  { "title": "Standards & guidance", "items": [
+    { "title": "Standards", "url": "/standards/", "icon": "fa-solid fa-certificate" },
+    { "title": "Guidance", "url": "/guidance/", "icon": "fa-solid fa-scroll" }
+  ]},
+  { "title": "About & policies", "items": [
+    { "title": "Brand", "url": "/brand/", "icon": "fa-solid fa-spray-can-sparkles" },
+    { "title": "Community", "url": "/community/", "icon": "fa-solid fa-circle-nodes" },
+    { "title": "Code of conduct", "url": "/conduct/", "icon": "fa-solid fa-scale-balanced" },
+    { "title": "Supporters", "url": "/supporters/", "icon": "fa-solid fa-heart" },
+    { "title": "Services", "url": "/services/", "icon": "fa-solid fa-wand-magic-sparkles" },
+    { "title": "Accessibility statement", "url": "/accessibility-statement/", "icon": "fa-solid fa-universal-access" },
+    { "title": "Privacy statement", "url": "/privacy-statement/", "icon": "fa-solid fa-user-shield" },
+    { "title": "Changelog", "url": "/changelog/", "icon": "fa-solid fa-timeline" },
+    { "title": "Contact", "url": "/contact/", "icon": "fa-solid fa-concierge-bell" },
+    { "title": "Feedback", "url": "/feedback/", "icon": "fa-solid fa-bullhorn" }
+  ]}
+]

--- a/_includes/layouts/docs.html
+++ b/_includes/layouts/docs.html
@@ -2,39 +2,22 @@
 {% include "nav.html" %}
 <main id="main-content">
   <article>
-    <div class="container mt-3">
-      <div class="row">
+    <div class="container-fluid mt-3">
+      <div class="row g-4">
         <div class="col-12 col-md-2">
           {% include "sidenav.html" %}
         </div>
         <div class="col-12 col-md-8">
           <div id="post">
-            {% if title %}<h1 class="display-5 pt-3 pb-2">{{ title }}</h1>{% endif %}
-            {% if description %}<p class="lead fs-4 pb-3 mb-4 border-bottom">{{ description }}</p>{% endif %}
+            {% include "post-badges.html" %}
+            {% if title %}<h1 class="pb-2">{{ title | safe }}</h1>{% endif %}
+            {% if description %}<p class="lead fs-4 pb-3 mb-4 border-bottom">{{ description | safe }}</p>{% endif %}
+            {% include "toc-mobile.html" %}
             {% include "scangov.html" %}
             {% include "image.html" %}
             {% include "audio.html" %}
-            <div class="post">
-              {{ content | safe }}
-            </div>
-            {% if website %}
-              <ul class="list-unstyled">
-            {% endif %}
-            {% if website %}
-              <li>
-                <i class="fa-solid fa-laptop"></i>
-                <a href="{{ website }}" class="">Website</a>
-              </li>
-            {% endif %}
-            {% if org %}
-              <li class="mt-2">
-                <i class="fa-solid fa-building"></i>
-                <a href="{{ orgLink }}" class="">{{ org }}</a>
-              </li>
-            {% endif %}
-            {% if website %}
-              </ul>
-            {% endif %}
+            {{ content | safe }}
+            {% include "post-links.html" %}
             {% include "related.html" %}
           </div>
         </div>

--- a/_includes/post-badges.html
+++ b/_includes/post-badges.html
@@ -1,0 +1,16 @@
+{% if isStandard %}
+  <div class="mb-4">
+    <a href="/" class="btn btn-primary-outline">
+      <i class="fa-solid fa-certificate" aria="hidden"></i>
+      Standard
+    </a>
+  </div>
+{% endif %}
+{% if isGuidance %}
+  <div class="mb-4">
+    <a href="/guidance" class="btn btn-primary-outline">
+      <i class="fa-solid fa-scroll" aria="hidden"></i>
+      Guidance
+    </a>
+  </div>
+{% endif %}

--- a/_includes/post-links.html
+++ b/_includes/post-links.html
@@ -1,0 +1,18 @@
+{% if website %}
+  <ul class="list-unstyled">
+{% endif %}
+{% if website %}
+  <li>
+    <i class="fa-solid fa-laptop"></i>
+    <a href="{{ website }}" class="">Website</a>
+  </li>
+{% endif %}
+{% if org %}
+  <li class="mt-2">
+    <i class="fa-solid fa-building"></i>
+    <a href="{{ orgLink }}" class="">{{ org }}</a>
+  </li>
+{% endif %}
+{% if website %}
+  </ul>
+{% endif %}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,10 +1,21 @@
 <nav class="d-none d-md-block js-sidenav position-sticky" style="top: 1rem;">
   <ul class="nav flex-column small">
-    {% for item in collections.pages | sort(false, false, 'data.title') %}
-      {% if item.data.icon %}
+    {% for item in sidenav %}
+      {% if item.items %}
+        <li class="nav-item mt-3 mb-1 text-uppercase text-secondary fw-bold">
+          {% if item.icon %}<i class="{{ item.icon }} me-2 fa-fw"></i>{% endif %}{{ item.title }}
+        </li>
+        {% for sub in item.items %}
+          <li class="nav-item mb-0 border-bottom">
+            <a href="{{ sub.url }}" class="text-body text-decoration-none d-block py-2 ps-3{% if page.url == sub.url %} fw-bold{% endif %}">
+              {% if sub.icon %}<i class="{{ sub.icon }} me-2 fa-fw"></i>{% endif %}{{ sub.title }}
+            </a>
+          </li>
+        {% endfor %}
+      {% else %}
         <li class="nav-item mb-0 border-bottom">
           <a href="{{ item.url }}" class="text-body text-decoration-none d-block py-2{% if page.url == item.url %} fw-bold{% endif %}">
-            <i class="{{ item.data.icon }} me-2 fa-fw"></i>{{ item.data.title }}
+            {% if item.icon %}<i class="{{ item.icon }} me-2 fa-fw"></i>{% endif %}{{ item.title }}
           </a>
         </li>
       {% endif %}

--- a/_includes/toc-mobile.html
+++ b/_includes/toc-mobile.html
@@ -1,0 +1,5 @@
+<div class="d-none js-on-this-page js-on-this-page-mobile mb-4">
+  <p class="border-bottom pb-3">On this page</p>
+  <ul class="nav flex-column">
+  </ul>
+</div>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,14 +1,13 @@
-<div class="d-none js-on-this-page">
+<div class="d-none js-on-this-page js-on-this-page-desktop">
   <p class="border-bottom pb-3">On this page</p>
   <ul class="nav flex-column">
   </ul>
 </div>
 <script>
-  const tocContainer = document.querySelector('.js-on-this-page ul');
-  if (tocContainer) {
-    const headings = document.querySelectorAll('#post h2, #post h3');
-    if (headings.length > 0) {
-      headings.forEach(function(heading) {
+  const headings = document.querySelectorAll('#post h2, #post h3');
+  if (headings.length > 0) {
+    document.querySelectorAll('.js-on-this-page ul').forEach(function (tocContainer) {
+      headings.forEach(function (heading) {
         const li = document.createElement('li');
         li.className = 'mb-2 small';
         if (heading.tagName === 'H3') {
@@ -20,8 +19,15 @@
         li.appendChild(a);
         tocContainer.appendChild(li);
       });
-      document.querySelector('.js-on-this-page').classList.add('d-md-block');
-      document.querySelector('.js-on-this-page').classList.remove('d-none');
+    });
+    const mobileToc = document.querySelector('.js-on-this-page-mobile');
+    if (mobileToc) {
+      mobileToc.classList.remove('d-none');
+      mobileToc.classList.add('d-md-none');
+    }
+    const desktopToc = document.querySelector('.js-on-this-page-desktop');
+    if (desktopToc) {
+      desktopToc.classList.add('d-md-block');
     }
   }
 </script>

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -1842,6 +1842,9 @@ th a:focus i, th a:focus svg {
     fill: var(--bs-body-color) !important;
 }
 /* Docs */
+#post h2 {
+    margin-top: 2.5rem;
+}
 #post h3 {
     margin-top: 2rem;
 }


### PR DESCRIPTION
Switch to the shared 3-column grid (sidebar/content/TOC) with a data-driven sidenav (_data/sidenav.json), add a mobile-only "on this page" block above the content, simplify the h1 styling, drop the redundant .post wrapper, and extract post-badges/post-links partials for parity with standards.