### PR TITLE
Add Pulse docs page, clarify Changelog scope

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -1,9 +1,9 @@
 ---
 title: "Changelog"
 date: 2025-02-15
-modified: 2026-07-17
+modified: 2026-07-25
 author: ScanGov
-description: "Timeline of changes to government websites."
+description: "Timeline of website changes."
 icon: "fa-solid fa-timeline"
 category: "product"
 topics:
@@ -12,7 +12,10 @@ topics:
 
 ## About
 
-The [ScanGov changelog](https://scangov.org/changelog) tracks changes in government websites' compliance with digital experience [standards](/standards) — accessibility, security, SEO, and more.
+Changelog tracks changes in a site's compliance with digital experience [standards](/standards) over time — accessibility, security, SEO, and more.
+
+- Each my.scangov.com site also has its own Changelog page (in the site sidebar), scoped to just that site.
+- The [ScanGov changelog](https://scangov.org/changelog) is public and covers every government site ScanGov monitors.
 
 ## Icons
 

--- a/content/pulse.md
+++ b/content/pulse.md
@@ -1,0 +1,23 @@
+---
+title: "Pulse"
+date: 2026-07-25
+description: "How the Pulse score trend chart works."
+icon: "fa-solid fa-wave-square"
+category: "product"
+topics:
+  - ScanGov
+---
+
+## About
+
+Pulse charts how a site's [indicator](/indicators) scores move over time. The full chart, on each site's Pulse page (in the site sidebar), plots Overall alongside all four indicators — Botability, Accessibility, Usability, Security — so you can see whether a site is trending up, down, or holding steady.
+
+A smaller version of the same chart appears on the [dashboard](/tasklist) and on each indicator page, scoped to that indicator only.
+
+## Reading the chart
+
+Each line's most recent point is clickable — Overall jumps to the dashboard, any indicator jumps to that indicator's page.
+
+## Why it matters
+
+A grade or score is a snapshot. Pulse shows the trend behind it — whether today's grade is the result of steady improvement, a recent regression, or no real change at all.


### PR DESCRIPTION
Changelog previously only described the public scangov.org version; now distinguishes it from the private per-site Changelog page on my.scangov.com.