### PR TITLE
Upgrade liquidjs, postcss to fix Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2015,9 +2015,9 @@
 			}
 		},
 		"node_modules/liquidjs": {
-			"version": "10.27.0",
-			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
-			"integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
+			"version": "10.27.2",
+			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.2.tgz",
+			"integrity": "sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w==",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^10.0.0"
@@ -2422,9 +2422,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2441,7 +2441,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -2463,9 +2463,9 @@
 			}
 		},
 		"node_modules/postcss/node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
 			"minimatch": {
 				"brace-expansion": "^5.0.8"
 			}
-		}
+		},
+		"liquidjs": "^10.27.2",
+		"postcss": "^8.5.23"
 	}
 }


### PR DESCRIPTION
Add npm overrides for liquidjs (^10.27.2, fixes pop filter memoryLimit bypass) and postcss (^8.5.23, fixes source map path traversal). brace-expansion GHSA-mh99 remains unresolved: 1.1.16 is the latest version on the 1.x line pulled in by @11ty/recursive-copy's minimatch@3.x, and no patched version exists for that line.